### PR TITLE
put . before version

### DIFF
--- a/postgres_kernel/__init__.py
+++ b/postgres_kernel/__init__.py
@@ -1,1 +1,1 @@
-from version import __version__
+from .version import __version__


### PR DESCRIPTION
My kernel kept dying with the error message "No module named version". I honestly don't know why this happens but I noticed that in the Jupyter source files all module names are preceded by a point. When I edited __init__.py on my computer to add the point this fixed the problem. (windows 10 x64, python 3.5.2, Anaconda, Jupyter 4.2.0)